### PR TITLE
C24q2 read yaml update

### DIFF
--- a/Database/Submit_Full_Regional_Model_SOLA.bat
+++ b/Database/Submit_Full_Regional_Model_SOLA.bat
@@ -282,21 +282,21 @@ if %counter% GTR 2 (goto loopend)
 REM AM Peak Skim
 call python macros/skim_transit.py %file1% %val% %counter% AM
 if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_triple_indexing.py %file1% AM
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_skim_final_matrices1.py
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_skim_wrapup.py %file1% AM
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_triple_indexing.py %file1% AM
+if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_skim_final_matrices1.py
+if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_skim_wrapup.py %file1% AM
+if %ERRORLEVEL% neq 0 (goto issue)
 REM Midday Skim
 call python macros/skim_transit.py %file1% %val% %counter% MD
 if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_triple_indexing.py %file1% MD
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_skim_final_matrices2.py
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
-rem --  call python macros/transit_skim_wrapup.py %file1% MD
-rem --  if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_triple_indexing.py %file1% MD
+if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_skim_final_matrices2.py
+if %ERRORLEVEL% neq 0 (goto issue)
+call python macros/transit_skim_wrapup.py %file1% MD
+if %ERRORLEVEL% neq 0 (goto issue)
 @ECHO    -- End of Transit Skim Procedures: %date% %time% >> model_run_timestamp.txt
 
 @ECHO Begin Global Iteration %counter%: %date% %time% >> model_run_timestamp.txt
@@ -317,8 +317,6 @@ call cmap_modedest . --njobs %jobs% --max_zone_chunk %zones%
 if %ERRORLEVEL% NEQ 0 (goto issue)
 @ECHO    -- End Mode-Destination Choice Procedures: %date% %time% >> model_run_timestamp.txt
 @ECHO.
-
-call python macros\transit_tod_vot.py
 
 rem Activate Emme Python env
 call %~dp0..\Scripts\manage\env\activate_env.cmd emme

--- a/Database/Submit_Full_Regional_Model_SOLA.bat
+++ b/Database/Submit_Full_Regional_Model_SOLA.bat
@@ -41,15 +41,15 @@ for /f "eol=# skip=9 tokens=2 delims=:" %%e in (batch_file.yaml) do (set selLink
 :break5
 for /f "eol=# skip=11 tokens=2 delims=:" %%f in (batch_file.yaml) do (set transitAsmt=%%f & goto break6)
 :break6
-for /f "eol=# skip=14 tokens=2 delims=:" %%g in (batch_file.yaml) do (set transitFilePath=%%g & goto break7)
+for /f "eol=# skip=14 tokens=2* delims=:" %%g in (batch_file.yaml) do (set transitFilePath1=%%g & set transitFilePath2=%%h & goto break7)
 :break7
-for /f "eol=# skip=16 tokens=2 delims=:" %%h in (batch_file.yaml) do (set selLineFile=%%h & goto break8)
+for /f "eol=# skip=16 tokens=2 delims=:" %%i in (batch_file.yaml) do (set selLineFile=%%i & goto break8)
 :break8
-for /f "eol=# skip=18 tokens=2 delims=:" %%i in (batch_file.yaml) do (set utilFile=%%i & goto break9)
+for /f "eol=# skip=18 tokens=2 delims=:" %%j in (batch_file.yaml) do (set utilFile=%%j & goto break9)
 :break9
-for /f "eol=# skip=20 tokens=2 delims=:" %%j in (batch_file.yaml) do (set UrbansimFile=%%j & goto break10)
+for /f "eol=# skip=20 tokens=2 delims=:" %%k in (batch_file.yaml) do (set UrbansimFile=%%k & goto break10)
 :break10
-for /f "eol=# skip=22 tokens=2 delims=:" %%k in (batch_file.yaml) do (set RSPrun=%%k & goto break11)
+for /f "eol=# skip=22 tokens=2 delims=:" %%l in (batch_file.yaml) do (set RSPrun=%%l & goto break11)
 :break11
 
 set val=%val:~1,3%
@@ -58,7 +58,11 @@ set wfh=%wfh:~1%
 set tc14=%tc14:~1%
 set selLinkFile=%selLinkFile:~1%
 set transitAsmt=%transitAsmt:~1,1%
-set transitFilePath=%transitFilePath:~1%
+rem Construct complete transit file path
+set transitFilePath1=%transitFilePath1:~1,-1%
+set transitFilePath2=%transitFilePath2:~1,-1%
+set sep=:\
+set transitFilePath=%transitFilePath1%%sep%%transitFilePath2%
 set selLineFile=%selLineFile:~1%
 set utilFile=%utilFile:~1,1%
 set UrbansimFile=%UrbansimFile:~1,1%
@@ -115,9 +119,14 @@ call %~dp0..\Scripts\manage\env\activate_env.cmd emme
 call python macros\verify_select_link.py %file1% %selLinkFile% %RSPrun% %trnAsmt%
 if %ERRORLEVEL% GTR 0 (goto end)
 
+SETLOCAL EnableDelayedExpansion
+set str1=%transitFilePath%\transit\tranmodes.txt
+REM Following line strips all quotes from str1
+set str2=!str1:^"=!
 if %trnAsmt% EQU 1 (
-    if not exist %transitFilePath%\transit\tranmodes.txt (goto transit_files_missing)
+    if not exist "%str2%" (goto transit_files_missing)
 )
+ENDLOCAL
 
 REM Clean up prior to run
 if exist cache\choice_simulator_trips_out (rmdir /S /Q cache\choice_simulator_trips_out)
@@ -141,7 +150,7 @@ if not "%choice%"=="" (
     set choice=%choice:~0,1%
     if "%choice%"=="1" (goto proceed)
     if "%choice%"=="2" (
-		set /a jobs=12
+		set /a jobs=11
 		set /a zones=7
 		set /a sola_threads=31
 		goto proceed
@@ -273,21 +282,21 @@ if %counter% GTR 2 (goto loopend)
 REM AM Peak Skim
 call python macros/skim_transit.py %file1% %val% %counter% AM
 if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_triple_indexing.py %file1% AM
-if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_skim_final_matrices1.py
-if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_skim_wrapup.py %file1% AM
-if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_triple_indexing.py %file1% AM
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_skim_final_matrices1.py
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_skim_wrapup.py %file1% AM
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
 REM Midday Skim
 call python macros/skim_transit.py %file1% %val% %counter% MD
 if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_triple_indexing.py %file1% MD
-if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_skim_final_matrices2.py
-if %ERRORLEVEL% neq 0 (goto issue)
-call python macros/transit_skim_wrapup.py %file1% MD
-if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_triple_indexing.py %file1% MD
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_skim_final_matrices2.py
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
+rem --  call python macros/transit_skim_wrapup.py %file1% MD
+rem --  if %ERRORLEVEL% neq 0 (goto issue)
 @ECHO    -- End of Transit Skim Procedures: %date% %time% >> model_run_timestamp.txt
 
 @ECHO Begin Global Iteration %counter%: %date% %time% >> model_run_timestamp.txt
@@ -308,6 +317,8 @@ call cmap_modedest . --njobs %jobs% --max_zone_chunk %zones%
 if %ERRORLEVEL% NEQ 0 (goto issue)
 @ECHO    -- End Mode-Destination Choice Procedures: %date% %time% >> model_run_timestamp.txt
 @ECHO.
+
+call python macros\transit_tod_vot.py
 
 rem Activate Emme Python env
 call %~dp0..\Scripts\manage\env\activate_env.cmd emme

--- a/Database/transit_asmt_macros/create_transit_demand.bat
+++ b/Database/transit_asmt_macros/create_transit_demand.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Prepare data for TOD transit assignments.
-REM  Heither, rev. 01-18-2024
+REM  Heither, rev. 04-25-2024 (improved logic for correctly reading transitFilePath)
 @echo -------------------------------------------------------------------------------------------------
 @echo create_transit_demand.bat
 @echo  Batch file does the following:
@@ -31,7 +31,7 @@ for /f "eol=# skip=2 tokens=2 delims=:" %%a in (batch_file.yaml) do (set val=%%a
 :break1
 for /f "eol=# skip=11 tokens=2 delims=:" %%f in (batch_file.yaml) do (set transitAsmt=%%f & goto break2)
 :break2
-for /f "eol=# skip=14 tokens=2 delims=:" %%b in (batch_file.yaml) do (set transitFilePath=%%b & goto break3)
+for /f "eol=# skip=14 tokens=2* delims=:" %%b in (batch_file.yaml) do (set transitFilePath1=%%b & set transitFilePath2=%%c & goto break3)
 :break3
 for /f "eol=# skip=16 tokens=2 delims=:" %%h in (batch_file.yaml) do (set selLineFile=%%h & goto break4)
 :break4
@@ -40,7 +40,11 @@ for /f "eol=# skip=22 tokens=2 delims=:" %%k in (batch_file.yaml) do (set RSPrun
 
 set val=%val:~1,3%
 set transitAsmt=%transitAsmt:~1,1%
-set transitFilePath=%transitFilePath:~1%
+rem Construct complete transit file path
+set transitFilePath1=%transitFilePath1:~1,-1%
+set transitFilePath2=%transitFilePath2:~1,-1%
+set sep=:\
+set transitFilePath=%transitFilePath1%%sep%%transitFilePath2%
 set selLineFile=%selLineFile:~1%
 set RSPrun=%RSPrun:~1,1%
 @echo.

--- a/Database/transit_asmt_macros/run_transit_assignment.bat
+++ b/Database/transit_asmt_macros/run_transit_assignment.bat
@@ -1,7 +1,6 @@
 @echo off
 REM Run transit assignment.
-REM  Heither, rev. 01-19-2024
-
+REM  Heither, rev. 04-25-2024 (improved logic for correctly reading transitFilePath)
 @echo -------------------------------------------------------------------------------------------------
 @echo To run a transit assignment, use the following settings in batch_file.yaml:
 @echo    - scenario: set to appropriate value
@@ -24,7 +23,7 @@ for /f "eol=# skip=2 tokens=2 delims=:" %%a in (batch_file.yaml) do (set val=%%a
 :break1
 for /f "eol=# skip=11 tokens=2 delims=:" %%f in (batch_file.yaml) do (set transitAsmt=%%f & goto break2)
 :break2
-for /f "eol=# skip=14 tokens=2 delims=:" %%b in (batch_file.yaml) do (set transitFilePath=%%b & goto break3)
+for /f "eol=# skip=14 tokens=2* delims=:" %%b in (batch_file.yaml) do (set transitFilePath1=%%b & set transitFilePath2=%%c & goto break3)
 :break3
 for /f "eol=# skip=16 tokens=2 delims=:" %%h in (batch_file.yaml) do (set selLineFile=%%h & goto break4)
 :break4
@@ -33,7 +32,11 @@ for /f "eol=# skip=22 tokens=2 delims=:" %%k in (batch_file.yaml) do (set RSPrun
 
 set val=%val:~1,3%
 set transitAsmt=%transitAsmt:~1,1%
-set transitFilePath=%transitFilePath:~1%
+rem Construct complete transit file path
+set transitFilePath1=%transitFilePath1:~1,-1%
+set transitFilePath2=%transitFilePath2:~1,-1%
+set sep=:\
+set transitFilePath=%transitFilePath1%%sep%%transitFilePath2%
 set selLineFile=%selLineFile:~1%
 set RSPrun=%RSPrun:~1,1%
 @echo.
@@ -55,7 +58,6 @@ set transitFilePath=%transitFilePath:~0,-1%
 if "%check2%" NEQ "None" (
     if not exist Select_Line\%selLineFile% (goto no_select_line_file)
 )
-pause
 
 REM -- Get name of .emp file --
 set infile=empfile.txt


### PR DESCRIPTION
Changes from c24q2 repo

batch_file.yml was updated to use ":" as a delimiter rather than "=". This caused issues with the batch files correctly reading the path to transit transaction files due to the colon in the path name. 

 - Submit_Full_Regional_Model_SOLA.bat:
    - Added code to correctly read path to transit transaction files from batch_file.yml with ":" as the delimiter.
    - Correctly builds path to verify tranmodes.txt exists in transaction file folder.
    - Revised number of jobs used if Run Mode 2 is selected from 12 to 11.

 - transit_asmt_macros\create_transit_demand.bat:
    - Added code to correctly read path to transit transaction files from batch_file.yml with ":" as the delimiter.

 - transit_asmt_macros\run_transit_assignment.bat:
    - Added code to correctly read path to transit transaction files from batch_file.yml with ":" as the delimiter.