### PR TITLE
Changes for sharing c24q4 standard data

### DIFF
--- a/Scripts/manage/env/emme-plus.yml
+++ b/Scripts/manage/env/emme-plus.yml
@@ -5,11 +5,11 @@ channels:
   - conda-forge
 dependencies:
   - jinja2
-  - markdown=3.4  # markdown v3.5 dropped support for python v3.7
+  - markdown
   - myst-parser
   - pyarrow
-  - python=3.7.6
+  - python=3.11.6
   - pyyaml
-  - sphinx=5.3
+  - sphinx
   - sphinx_rtd_theme
   - tqdm

--- a/Scripts/manage/env/emme.pth
+++ b/Scripts/manage/env/emme.pth
@@ -2,4 +2,4 @@
 #  Copyright: (c) Bentley Systems, Incorporated. All rights reserved.
 #
 
-import os, site; site.addsitedir(os.path.join(os.environ["EMMEPATH"], "Python37/Lib/site-packages"))
+import os, site; site.addsitedir(os.path.join(os.environ["EMMEPATH"], "Python311/Lib/site-packages"))

--- a/Scripts/share/standard_data/hand/data_user_guide_md.txt
+++ b/Scripts/share/standard_data/hand/data_user_guide_md.txt
@@ -351,7 +351,7 @@ contain nodes and links for peak and off-peak. Itins_pk and itins_op are the
 transit route itineraries for peak and off-peak. Attribs_pk and attribs_op are
 segment variables for the transit itineraries for peak and off-peak. Within
 attribs_pk and attribs_op, @ltime is the current scheduled time on the link,
-@hwytm is the modeled period auto travel time on the same link, and @zfare is
+@hwytm is the modeled period auto travel time on the same link, and @zfare_link is
 an attribute describing points where extra fares are charged.
 
 Transit Network Codes

--- a/Scripts/share/standard_data/src/standard_data.py
+++ b/Scripts/share/standard_data/src/standard_data.py
@@ -228,7 +228,7 @@ def compress(zip_file_names, source_paths):
         mp_compress_args.append((file_name, source_paths[placeholder], _out_dir))
     # Compress model data for sharing.
     logging.info('Compressing outputs')
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(processes=min(os.cpu_count(), 61)) as pool:
         # Display a progress bar while processing the tasks.
         for i in tqdm(iterable=pool.imap_unordered(func=sharing.mp_compress,
                                                    iterable=mp_compress_args),

--- a/Scripts/tbmtools/results/person_trips.py
+++ b/Scripts/tbmtools/results/person_trips.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import multiprocessing
+import os
 import pandas as pd
 
 def export_matrix_from_roster(name, spec, outdir, roster, report):
@@ -146,7 +147,7 @@ def export_auto_matrices(projdir, outdir, trip_roster_path):
     args = []
     for name, spec in mtx_specs.items():
         args.append((name, spec, tripdir, roster, report))
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(processes=min(os.cpu_count(), 61)) as pool:
         pool.starmap(export_matrix_from_roster, args)
     # Move HOV matrices to output directory.
     for p in sorted(tripdir.glob('*.csv')):

--- a/Scripts/tbmtools/results/sharing.py
+++ b/Scripts/tbmtools/results/sharing.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from zipfile import ZipFile, ZIP_LZMA
+from zipfile import ZipFile, ZIP_DEFLATED
 
 
 def mp_compress(args):
@@ -33,7 +33,7 @@ def compress(out_file_name, source_path, out_dir):
     if isinstance(source_path, str):
         source_path = Path(source_path).resolve()
     # Compress content.
-    with ZipFile(out_dir.joinpath(out_file_name), mode='w', compression=ZIP_LZMA) as zip:
+    with ZipFile(out_dir.joinpath(out_file_name), mode='w', compression=ZIP_DEFLATED, compresslevel=9) as zip:
         if source_path.is_file():
             zip.write(source_path, arcname=source_path.name)
         elif source_path.is_dir():

--- a/Scripts/tbmtools/results/transit_network.py
+++ b/Scripts/tbmtools/results/transit_network.py
@@ -58,7 +58,7 @@ def export(outdir, scenario, format, modeller, emmebank, period=[0, 5]):
                          scenario=s)
             # Write attribute transaction file.
             spec = {'type': 'NETWORK_CALCULATION',
-                    'expression': '@ltime + @hwytm + @zfare',
+                    'expression': '@ltime + @hwytm + @zfare_link',
                     'selections': {'link': 'all',
                                    'transit_line': 'all'}}
             report = net_calc(specification=spec,


### PR DESCRIPTION
* Upgrade the emme-plus env to Python v3.11 and EMME v24
* Use a compression algorithm that is natively supported in Windows to create ZIP files that don't require 7-Zip for extraction
* Avoid a multiprocessing error that occurs on Windows machines with many processors
* Update the zone fare attribute name that was changed for use in the ABM