### PR TITLE
53 fix wfh data input columns in trip generation modelpy

### DIFF
--- a/Database/trip_generation/trip_generation_model.py
+++ b/Database/trip_generation/trip_generation_model.py
@@ -303,12 +303,10 @@ totalHHs = sz['households'].sum()
 sz.drop(szDrop, axis=1, inplace=True)
 
 # Load household work from home flag file
-wfhCols = ['serial_number','wfh_flag','number_WFH_workers','tc14_not_working']
-wfhDrop = ['number_WFH_workers','tc14_not_working']
-wfh = pd.read_csv(wfhFile, names=wfhCols, engine=pdEngine)
+wfhCols = ['serial_number','wfh_flag','number_WFH_workers']  
+wfh = pd.read_csv(wfhFile, names=wfhCols, engine=pdEngine, usecols=[0, 1, 2])
 wfh['household_record'] = wfh.index + 1
 wfh['wfh_flag'] = wfh['wfh_flag'].clip(upper=1)
-wfh.drop(wfhDrop, axis=1, inplace=True)
 
 # Load household vehicle type category file
 hhvtype = pd.read_csv(hhvtypeFile, dtype='Int64', engine=pdEngine)

--- a/Database/trip_generation/trip_generation_model.py
+++ b/Database/trip_generation/trip_generation_model.py
@@ -303,8 +303,8 @@ totalHHs = sz['households'].sum()
 sz.drop(szDrop, axis=1, inplace=True)
 
 # Load household work from home flag file
-wfhCols = ['serial_number','wfh_flag','number_WFH_workers']  
-wfh = pd.read_csv(wfhFile, names=wfhCols, engine=pdEngine, usecols=[0, 1, 2])
+wfhCols = ['serial_number','wfh_flag']  
+wfh = pd.read_csv(wfhFile, names=wfhCols, engine=pdEngine, usecols=[0, 1])
 wfh['household_record'] = wfh.index + 1
 wfh['wfh_flag'] = wfh['wfh_flag'].clip(upper=1)
 


### PR DESCRIPTION
updated code to read in only the first two columns of the WFH file since that's all the script needs; this way the input file can have as many columns as it wants but it will only read in the 2 it needs 